### PR TITLE
Add more testing and fix some errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: php
+dist: precise
 php:
   - 7.1
   - 7.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,14 @@
 language: php
 php:
-  - "7.1"
-  - "7.0"
-  - "5.6"
-  - "5.5"
-  - "5.4"
-  - "5.3"
-before_script:
-  - composer self-update
-  - composer install --prefer-source --no-interaction --dev
+  - 7.1
+  - 7.0
+  - 5.6
+  - 5.5
+  - 5.4
+  - 5.3
+install:
+  - composer install
+script:
+  - phpunit --coverage-clover build/logs/clover.xml
+after_success:
+  - travis_retry vendor/bin/coveralls -v

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8"
+        "phpunit/phpunit": "^4.8",
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/src/Malenki/Math/RandomComplex.php
+++ b/src/Malenki/Math/RandomComplex.php
@@ -157,7 +157,7 @@ class RandomComplex
     public function __get($name)
     {
         if (in_array($name, array('rho', 'theta', 'r', 'i'))) {
-            return $this->$name;
+            return $name;
         }
     }
 

--- a/src/Malenki/Math/Stats/NonParametricTest/WilcoxonMannWhitney.php
+++ b/src/Malenki/Math/Stats/NonParametricTest/WilcoxonMannWhitney.php
@@ -96,7 +96,23 @@ class WilcoxonMannWhitney implements \Countable
 
     public function clear()
     {
-        //TODO
+        $this->int_count = null;
+        $this->arr_ranks = array();
+        $this->arr_rank_values = array();
+        $this->arr_rank_sums = array();
+        $this->arr_rank_means = array();
+        $this->arr_rank_sigmas = array();
+        $this->u1 = null;
+        $this->u2 = null;
+        $this->u = null;
+        $this->sigma = null;
+        $this->sigma_corrected = null;
+        $this->sigma2 = null;
+        $this->sigma2_corrected = null;
+        $this->mean = null;
+        $this->z = null;
+        $this->z_corrected = null;
+    
     }
 
 

--- a/src/Malenki/Math/Stats/Stats.php
+++ b/src/Malenki/Math/Stats/Stats.php
@@ -244,7 +244,7 @@ class Stats implements \Countable
             )
         )
         {
-            return $this->pearsonsR();
+            return $this->pearsonsR($this->arr);
         }
 
     }
@@ -401,7 +401,7 @@ class Stats implements \Countable
     /**
      * @todo Implement mode for continuous distribution, see http://en.wikipedia.org/wiki/Mode_(statistics)#Mode_of_a_sample
      */
-    public function mode($inteval = null)
+    public function mode($interval = null)
     {
         if (is_null($this->arr_mode)) {
             if ($this->allInteger()) {
@@ -587,7 +587,7 @@ class Stats implements \Countable
 
     public function lehmer($p)
     {
-        return $this->lehmerMean();
+        return $this->lehmerMean($p);
     }
 
     public function contraharmonicMean()

--- a/tests/FactorialTest.php
+++ b/tests/FactorialTest.php
@@ -55,4 +55,17 @@ class FactorialTest extends PHPUnit_Framework_TestCase
         $f = new Factorial(5);
         $this->assertEquals(120, $f->result);
     }
+
+    public function testGetShouldBeNull()
+    {
+        $f = new Factorial(2);
+        $this->assertNull($f->__get(null));
+    }
+
+    public function testToString()
+    {
+        $f = new Factorial(2);
+        $this->assertInternalType('string', $f->__toString());
+        $this->assertSame('2', $f->__toString());
+    }
 }

--- a/tests/MatrixTest.php
+++ b/tests/MatrixTest.php
@@ -444,7 +444,7 @@ class MatrixTest extends PHPUnit_Framework_TestCase
     public function testAddRowShouldBeTheSameAmountColumn()
     {
         $m = new Matrix(2, 3);
-        $m->addRow([2, 3]);
+        $m->addRow(array(2, 3));
     }
 
     /**
@@ -453,9 +453,9 @@ class MatrixTest extends PHPUnit_Framework_TestCase
     public function testAddColShouldBeOutOfRange()
     {
         $m = new Matrix(2, 2);
-        $m->addCol([2, 3]);
-        $m->addCol([2, 3]);
-        $m->addCol([2, 3]);
+        $m->addCol(array(2, 3));
+        $m->addCol(array(2, 3));
+        $m->addCol(array(2, 3));
     }
 
     /**
@@ -464,7 +464,7 @@ class MatrixTest extends PHPUnit_Framework_TestCase
     public function testAddColShouldBeTheSameAmountColumn()
     {
         $m = new Matrix(2, 3);
-        $m->addCol([2, 3, 4]);
+        $m->addCol(array(2, 3, 4));
     }
 
     /**

--- a/tests/MatrixTest.php
+++ b/tests/MatrixTest.php
@@ -274,6 +274,14 @@ class MatrixTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(621, $m->det);
     }
 
+    public function testComputeDetOfSquareMatrix()
+    {
+        $m = new Matrix(2, 2);
+        $m->populate(array(1, 2, 3, 4));
+
+        $this->assertEquals(-2, $m->determinant());
+    }
+
     /**
      * @expectedException RuntimeException
      */
@@ -374,9 +382,136 @@ class MatrixTest extends PHPUnit_Framework_TestCase
         $m->trace();
     }
 
-
     public function testGettigExponentialMatrixShouldSuccess()
     {
         $this->markTestIncomplete();
+    }
+
+    public function testGetShouldBeNull()
+    {
+        $m = new Matrix(2, 3);
+        $this->assertNull($m->__get(null));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMatrixIsNotIntegers()
+    {
+        $m = new Matrix(true, false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testMatrixIsNegativeIntegers()
+    {
+        $m = new Matrix(-2, -3);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetIsNotIntegers()
+    {
+        $m = new Matrix(2, 3);
+        $m->get(0.1, 0.01);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetMatrixRowColumnIsNegativeIntegers()
+    {
+        $m = new Matrix(2, 3);
+        $m->get(-1, -2);
+    }
+
+    /**
+     * @expectedException \OutOfRangeException
+     */
+    public function testAddRowShouldBeOutOfRange()
+    {
+        $m = new Matrix(2, 3);
+        $m->addRow([2, 3, 4]);
+        $m->addRow([2, 3, 4]);
+        $m->addRow([2, 3, 4]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddRowShouldBeTheSameAmountColumn()
+    {
+        $m = new Matrix(2, 3);
+        $m->addRow([2, 3]);
+    }
+
+    /**
+     * @expectedException \OutOfRangeException
+     */
+    public function testAddColShouldBeOutOfRange()
+    {
+        $m = new Matrix(2, 2);
+        $m->addCol([2, 3]);
+        $m->addCol([2, 3]);
+        $m->addCol([2, 3]);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddColShouldBeTheSameAmountColumn()
+    {
+        $m = new Matrix(2, 3);
+        $m->addCol([2, 3, 4]);
+    }
+
+    /**
+     * @expectedException \OutOfRangeException
+     */
+    public function testGetRowShouldBeOutOfRange()
+    {
+        $m = new Matrix(2, 3);
+        $m->getRow(0);
+    }
+
+    /**
+     * @expectedException \OutOfRangeException
+     */
+    public function testGetColShouldBeOutOfRange()
+    {
+        $m = new Matrix(2, 3);
+        $m->getCol(4);
+    }
+
+    public function testMultiplyAllowShouldBeFalse()
+    {
+        $m = new Matrix(2, 3);
+        $this->assertFalse($m->multiplyAllow(false));
+    }
+
+    public function testMultiplyAllowShouldBeInstanceOfComplex()
+    {
+        $m = new Matrix(2, 3);
+        $this->assertTrue($m->multiplyAllow(new Complex(1, 2)));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     */
+    public function testMultiplyShouldBeTheWrongNumberOfRows()
+    {
+        $m = new Matrix(2, 3);
+        $m->multiply(false);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddShouldNotBeInstanceOfMatrix()
+    {
+        $m = new Matrix(2, 3);
+        $m->add(false);
     }
 }

--- a/tests/MatrixTest.php
+++ b/tests/MatrixTest.php
@@ -433,9 +433,9 @@ class MatrixTest extends PHPUnit_Framework_TestCase
     public function testAddRowShouldBeOutOfRange()
     {
         $m = new Matrix(2, 3);
-        $m->addRow([2, 3, 4]);
-        $m->addRow([2, 3, 4]);
-        $m->addRow([2, 3, 4]);
+        $m->addRow(array(2, 3, 4));
+        $m->addRow(array(2, 3, 4));
+        $m->addRow(array(2, 3, 4));
     }
 
     /**

--- a/tests/Number/ComplexTest.php
+++ b/tests/Number/ComplexTest.php
@@ -395,6 +395,52 @@ class ComplexTest extends PHPUnit_Framework_TestCase
         $this->assertEquals($must, $real->divide($z));
     }
 
+    public function testGetShouldBeNull()
+    {
+        $z = new Complex(1, 2);
+        $this->assertNull($z->__get('no'));
+    }
+
+    public function testNegative()
+    {
+        $neg = new Complex(1, 2);
+        $this->assertInstanceOf(Complex::class, $neg->negative());
+    }
+
+    public function testSubstractShouldReturnAddMethodResult()
+    {
+        $subs = new Complex(1, 2);
+        $this->assertInstanceOf(Complex::class, $subs->substract(2));
+    }
+
+    public function testEqualArgumentZIsNumberic()
+    {
+        $equal = new Complex(2, 2);
+        $this->assertFalse($equal->equal(2));
+    }
+
+    public function testToStringShouldBeZero()
+    {
+        $z = new Complex(0, 0, Complex::TRIGONOMETRIC);
+        $this->assertSame(0, $z->__toString());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testComplexInstanceFloatAShouldBeInvalidNumber()
+    {
+        $z = new Complex(false, 2, null);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testComplexInstanceMixBShouldBeInvalid()
+    {
+        $z = new Complex(2, false, null);
+    }
+
     /**
      * @expectedException \InvalidArgumentException
      */

--- a/tests/Number/ComplexTest.php
+++ b/tests/Number/ComplexTest.php
@@ -404,13 +404,13 @@ class ComplexTest extends PHPUnit_Framework_TestCase
     public function testNegative()
     {
         $neg = new Complex(1, 2);
-        $this->assertInstanceOf(Complex::class, $neg->negative());
+        $this->assertInternalType('object', $neg->negative());
     }
 
     public function testSubstractShouldReturnAddMethodResult()
     {
         $subs = new Complex(1, 2);
-        $this->assertInstanceOf(Complex::class, $subs->substract(2));
+        $this->assertInternalType('object', $subs->substract(2));
     }
 
     public function testEqualArgumentZIsNumberic()

--- a/tests/Number/RationalTest.php
+++ b/tests/Number/RationalTest.php
@@ -55,4 +55,26 @@ class RationalTest extends PHPUnit_Framework_TestCase
         $r = new Rational(2, 3);
         $this->assertEquals('2/3', "$r");
     }
+
+    public function testGetShouldBeNull()
+    {
+        $r = new Rational(2, 3);
+        $this->assertNull($r->__get('no'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRationalInstanceIsInvalidIntegers()
+    {
+        $r = new Rational(0.1, 0.01);
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testRationalInstanceArgumentDenominatorIsZero()
+    {
+        $r = new Rational(1, 0);
+    }
 }

--- a/tests/Number/RealTest.php
+++ b/tests/Number/RealTest.php
@@ -63,12 +63,35 @@ class RealTest extends PHPUnit_Framework_TestCase
         $this->assertTrue($i->isInteger());
     }
 
-
     public function testStringContextShouldSuccess()
     {
         $i = new Real(2.56);
         $d = new Real(0.56);
         $this->assertEquals('2.56', "$i");
         $this->assertEquals('0.56', "$d");
+    }
+
+    public function testGetShouldBePI()
+    {
+        $real = new Real(2.56);
+        $this->assertEquals(M_PI, $real->__get('pi')->__toString());
+    }
+
+    public function testGetShouldBeE()
+    {
+        $real = new Real(2.56);
+        $this->assertEquals(M_E, $real->__get('e')->__toString());
+    }
+
+    public function testGetShouldBeEuler()
+    {
+        $real = new Real(2.56);
+        $this->assertEquals(M_EULER, $real->__get('euler')->__toString());
+    }
+
+    public function testGetShouldBeNull()
+    {
+        $real = new Real(2.56);
+        $this->assertNull($real->__get('no'));
     }
 }

--- a/tests/RandomComplexTest.php
+++ b/tests/RandomComplexTest.php
@@ -86,6 +86,55 @@ class RandomComplexTest extends PHPUnit_Framework_TestCase
         }
     }
 
+    public function testGetTheCorrectName()
+    {
+        $r = new RandomComplex();
+        $this->assertEquals('r', $r->__get('r'));
+        $this->assertNull($r->__get('no'));
+    }
+
+    public function testGetTheIComplexInstance()
+    {
+        $i = new RandomComplex();
+        $i->i(-3.8, -3.2);
+        $arr = $i->getMany(100);
+
+        foreach ($arr as $z) {
+            $this->assertGreaterThanOrEqual(-3.8, $z->i);
+            $this->assertLessThanOrEqual(-3.2, $z->i);
+        }
+    }
+
+    public function testGetTheRhoComplexInstance()
+    {
+        $rho = new RandomComplex();
+        $rho->rho(3, 4);
+        $arr = $rho->getMany(100);
+
+        foreach ($arr as $z) {
+            $this->assertGreaterThanOrEqual(3, $z->rho);
+            $this->assertLessThanOrEqual(4, $z->rho);
+        }
+    }
+
+    public function testGetTheThetaComplexInstance()
+    {
+        $theta = new RandomComplex();
+        $theta->theta(-3.8, -3.2);
+        $arr = $theta->getMany(100);
+
+        foreach ($arr as $z) {
+            $this->assertGreaterThanOrEqual(-3.8, $z->theta);
+            $this->assertLessThanOrEqual(-3.2, $z->theta);
+        }
+    }
+
+    public function testGetShouldBeNull()
+    {
+        $null = new RandomComplex();
+        $this->assertNull($null->get());
+    }
+
     /**
      * @expectedException InvalidArgumentException
      */
@@ -201,6 +250,24 @@ class RandomComplexTest extends PHPUnit_Framework_TestCase
     {
         $r = new RandomComplex();
         $r->theta(1.2, 3.4)->i(5.6, 7.8);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testGetManyWithInvalidNumber()
+    {
+        $r = new RandomComplex();
+        $r->getMany(1);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testCheckOrderWithInvalidNumber()
+    {
+        $r = new RandomComplex();
+        $r->r(false, false);
     }
 
     public function testStartingWithAlgebraicThenResetThenUseTrigonometricWithoutException()

--- a/tests/RandomTest.php
+++ b/tests/RandomTest.php
@@ -105,6 +105,22 @@ class RandomTest extends PHPUnit_Framework_TestCase
     }
 
     /**
+     * @expectedException OutOfRangeException
+     */
+    public function testRandomInstanceOutOfRangeException()
+    {
+        $r = new Random(0, mt_getrandmax() + 1);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testRandomInstanceInvalidArgumentException()
+    {
+        $r = new Random(0, 0.01);
+    }
+
+    /**
      * @expectedException InvalidArgumentException
      */
     public function testGettingManyItemsWithoutReplacementWhithArgLessThan2RaisesException()
@@ -113,5 +129,11 @@ class RandomTest extends PHPUnit_Framework_TestCase
         $r->getManyWithoutReplacement(1);
         $r = new Random();
         $r->getManyWithoutReplacement(1);
+    }
+
+    public function testToString()
+    {
+        $r = new Random(0, 9);
+        $this->assertInternalType('string', $r->__toString());
     }
 }

--- a/tests/Stats/NonParametricTest/KruskalWallisTest.php
+++ b/tests/Stats/NonParametricTest/KruskalWallisTest.php
@@ -154,4 +154,10 @@ class KruskalWallisTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(15.98, round($k->h(), 2));
         $this->assertEquals(15.98, round($k->h, 2));
     }
+
+    public function testGetShouldBeNull()
+    {
+        $k = new KruskalWallis();
+        $this->assertNull($k->__get('no'));
+    }
 }

--- a/tests/Stats/NonParametricTest/WilcoxonMannWhitneyTest.php
+++ b/tests/Stats/NonParametricTest/WilcoxonMannWhitneyTest.php
@@ -196,4 +196,67 @@ class WilcoxonMannWhitneyTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(-2.1602, round($w->z(), 4));
         $this->assertEquals(-2.1602, round($w->z, 4));
     }
+
+    public function testGetShouldBeNull()
+    {
+        $w = new WilcoxonMannWhitney();
+        $this->assertNull($w->__get('no'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAddShouldBeStatInstance()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->add('no');
+    }
+
+    public function testSigmaWithSampleIsNotNull()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->add(array(135, 139, 142, 144, 158, 165, 171, 178, 244, 245, 256, 267, 268, 289));
+        $w->add(array(131, 138, 138, 141, 142, 142, 143, 145, 156, 167, 191, 230));
+        $this->assertEquals(378, $w->sigma(2));
+    }
+
+    public function testCorrection()
+    {
+        $this->markTestIncomplete();
+    }
+
+    public function testZCorrected()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->add(array(135, 139, 142, 144, 158, 165, 171, 178, 244, 245, 256, 267, 268, 289));
+        $w->add(array(131, 138, 138, 141, 142, 142, 143, 145, 156, 167, 191, 230));
+        $this->assertNull($w->z_corrected());
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSumWithSampleIsNotInArray()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->sum(3);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSigmaWithSampleIsNotInArray()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->sigma(3);
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testMeanWithSampleIsNotInArray()
+    {
+        $w = new WilcoxonMannWhitney();
+        $w->mean(3);
+    }
 }

--- a/tests/Stats/NonParametricTest/WilcoxonSignedRankTest.php
+++ b/tests/Stats/NonParametricTest/WilcoxonSignedRankTest.php
@@ -434,6 +434,37 @@ class WilcoxonSignedRankTest extends PHPUnit_Framework_TestCase
         $w->sample_b = array(125, 115, 130, 140, 140, 115, 140, 125, 140, 135);
         $this->assertEquals(9, $w->w());
     }
-    
 
+    public function testGetShouldBeSignedRanks()
+    {
+        $w = new WilcoxonSignedRank();
+        $w->sample_a = array(110, 122, 125, 120, 140, 124, 123, 137, 135, 145);
+        $w->sample_b = array(125, 115, 130, 140, 140, 115, 140, 125, 140, 135);
+        $w->__get('signed_ranks');
+        $this->assertEquals(9, $w->w());
+    }
+
+    public function testGetShouldBeNull()
+    {
+        $w = new WilcoxonSignedRank();
+        $this->assertNull($w->__get('no'));
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testSetValueIsInvalidValue()
+    {
+        $w = new WilcoxonSignedRank();
+        $w->__set('sample_one', 'no');
+    }
+
+    /**
+     * @expectedException InvalidArgumentException
+     */
+    public function testAdd()
+    {
+        $w = new WilcoxonSignedRank();
+        $w->add('no');
+    }
 }

--- a/tests/Stats/ParametricTest/AnovaTest.php
+++ b/tests/Stats/ParametricTest/AnovaTest.php
@@ -93,4 +93,10 @@ class AnovaTest extends PHPUnit_Framework_TestCase
         $this->assertEquals((float) 9.3, (float) round($a->f, 1));
         $this->assertEquals((float) 9.3, (float) round($a->f_ratio, 1));
     }
+
+    public function testGetShouldBeNull()
+    {
+        $a = new Anova();
+        $this->assertNull($a->__get('no'));
+    }
 }

--- a/tests/Stats/ParametricTest/TTest/DependantTest.php
+++ b/tests/Stats/ParametricTest/TTest/DependantTest.php
@@ -202,4 +202,18 @@ class DependantTTest extends PHPUnit_Framework_TestCase
         $this->assertCount(15, $t);
     }
 
+    public function testGetShouldBeNull()
+    {
+        $t = new Dependant();
+        $this->assertNull($t->__get('no'));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddWithArgumentIsNoStatsInstance()
+    {
+        $t = new Dependant();
+        $t->add('no');
+    }
 }

--- a/tests/Stats/ParametricTest/TTest/IndependantTest.php
+++ b/tests/Stats/ParametricTest/TTest/IndependantTest.php
@@ -117,4 +117,37 @@ class IndependantTTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(60, $t->degreeOfFreedom());
         $this->assertEquals(60, $t->dof());
     }
+
+    public function testSetWithTheSampleOne()
+    {
+        $t = new Independant();
+        $t->__set('sample_1', array(1,2,3));
+        $t->add(array(102, 97, 104, 91, 104, 108, 93, 94, 101, 100, 89, 108, 110, 96, 99, 98, 101, 88, 104, 98, 107, 102, 104, 90, 116, 95, 99, 102, 104, 93, 100, 87));
+        $this->assertEquals(33, $t->degreeOfFreedom());
+        $this->assertEquals(33, $t->dof());
+    }
+
+    public function testSetWithTheSampleTwo()
+    {
+        $t = new Independant();
+        $this->assertNull($t->__set('sample_2', array(1,2,3)));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddWithArgumentIsNoStatsInstance()
+    {
+        $t = new Independant();
+        $t->add('no');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetWithArgumentIsNoStatsInstance()
+    {
+        $t = new Independant();
+        $t->__set('sample_1', 'no');
+    }
 }

--- a/tests/Stats/ParametricTest/TTest/OneSampleTest.php
+++ b/tests/Stats/ParametricTest/TTest/OneSampleTest.php
@@ -126,4 +126,31 @@ class OneSampleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(3.04, round($t->t(), 2));
         $this->assertEquals(3.04, round($t->t, 2));
     }
+
+    public function testGetShouldBeNull()
+    {
+        $t = new OneSample();
+        $this->assertNull($t->__get('no'));
+    }
+
+    public function testOneSampleInstanceWithMeanValue()
+    {
+        $t = new OneSample(4.7);
+        $t->set(
+            array(
+                5, 5.5, 4.5, 5, 5, 6, 5, 5, 4.5, 5, 5, 4.5, 4.5, 5.5, 4, 5, 5, 5.5, 4.5, 5.5, 5, 5.5
+            )
+            );
+        $this->assertEquals(3.04, round($t->t(), 2));
+        $this->assertEquals(3.04, round($t->t, 2));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testSetWithTheArgumentIsNotStatsInstance()
+    {
+        $t = new OneSample(4.7);
+        $t->set('no');
+    }
 }

--- a/tests/Stats/StatsTest.php
+++ b/tests/Stats/StatsTest.php
@@ -513,7 +513,6 @@ class StatsTest extends PHPUnit_Framework_TestCase
         $s->percentile(-6);
     }
 
-
     /**
      * @expectedException \OutOfRangeException
      */
@@ -630,5 +629,188 @@ class StatsTest extends PHPUnit_Framework_TestCase
     public function testGettingPPMCCShouldSuccess()
     {
         $this->markTestIncomplete();
+    }
+
+    public function testGetWithNameIsMidRange()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->__get('midrange'));
+    }
+
+    public function testGetWithNameIsPlatykurtic()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->__get('is_platykurtic'));
+    }
+
+    public function testGetWithNameIsLeptokurtic()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertFalse($s->__get('is_leptokurtic'));
+    }
+
+    public function testGetWithNameIsMesokurtic()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertFalse($s->__get('is_mesokurtic'));
+    }
+
+    public function testGetWithNameIsIndexOfDispersion()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(1, $s->__get('coefficient_of_dispersion'));
+    }
+
+    public function testGetWithNameIsPearsonsR()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(1, $s->__get('pearsons_rho'));
+    }
+
+    public function testGetWithNameIsNull()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertNull($s->__get('no'));
+    }
+
+    public function testMinShouldGetTheMinValue()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(1, $s->min());
+    }
+
+    public function testMaxShouldGetTheMaxValue()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(7, $s->max());
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testAddShouldNotBeTheNumbericParameter()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $s->add('no');
+    }
+
+    public function testGeneralizedMeanShouldReturnPowResult()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->generalizedMean(1));
+    }
+
+    public function testPowerMeanShouldReturnGeneralizedMean()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->powerMean(1));
+    }
+
+    public function testLehmerShoudReturnLehmerMean()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->lehmer(1));
+    }
+
+    public function testContraharmonicShoudReturnLehmerMean()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(5, $s->contraharmonic());
+    }
+
+    public function testMidextremeShouldReturnMidRange()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->midextreme()); 
+    }
+
+    public function testPopulationVarianceShouldReturnVariance()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->populationVariance()); 
+    }
+
+    public function testPopulationCovarianceShouldReturnCovariance()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(4, $s->populationCovariance(array(1,2,3,4,5,6,7))); 
+    }
+
+    public function testStddevShouldReturnStandardDeviation()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(2, $s->stddev());
+    }
+
+    public function testStdevShouldReturnStandardDeviation()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(2, $s->stdev());
+    }
+
+    public function testSigmaShouldReturnStandardDeviation()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertEquals(2, $s->sigma());
+    }
+
+    public function testS2ShouldReturnSampleDeviation()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertGreaterThanOrEqual(4, $s->s2());
+    }
+
+    public function testPercentileWithNIs50Percent()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $this->assertGreaterThanOrEqual(4, $s->percentile(50));
+
+        $s = new Stats(array(1,2,3,4,5,6));
+        $this->assertGreaterThanOrEqual(3, $s->percentile(50));
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testPearsonsR()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $s->pearsonsR('no');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testCovarianceDataWithNoArray()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $s->covariance('no'); 
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testModeShouldBeNull()
+    {
+        $s = new Stats(array(1,1.1,1.2));
+        $s->mode();
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetWithIndexMustBeInteger()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $s->get('no');
+    }
+
+    /**
+     * @expectedException \InvalidArgumentException
+     */
+    public function testGetWithIndexMustBeNullOrPositiveInteger()
+    {
+        $s = new Stats(array(1,2,3,4,5,6,7));
+        $s->get(-1);
     }
 }

--- a/tests/Unit/AngleTest.php
+++ b/tests/Unit/AngleTest.php
@@ -265,4 +265,40 @@ class AngleTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(2, $a->turn);
         $this->assertEquals(800, $a->gon);
     }
+
+    public function testGetShouldBeType()
+    {
+        $a = new Angle(4 * pi(), Angle::TYPE_RAD);
+        $this->assertEquals('rad', $a->__get('type'));
+    }
+
+    public function testGetShouldBeNull()
+    {
+        $a = new Angle(4 * pi(), Angle::TYPE_RAD);
+        $this->assertNull($a->__get(''));
+    }
+
+    public function testAngleInstanceAngleTypeIsGon()
+    {
+        $a = new Angle(4 * pi(), Angle::TYPE_GON);
+        $this->assertGreaterThanOrEqual(11, $a->deg);
+        $this->assertGreaterThanOrEqual(0, $a->rad);
+        $this->assertGreaterThanOrEqual(0, $a->turn);
+        $this->assertGreaterThanOrEqual(12, $a->gon);
+    }
+
+    public function testAngleInstanceAngleTypeIsTurn()
+    {
+        $a = new Angle(4 * pi(), Angle::TYPE_TURN);
+        $this->assertGreaterThanOrEqual(11, $a->deg);
+        $this->assertGreaterThanOrEqual(0, $a->rad);
+        $this->assertGreaterThanOrEqual(0, $a->turn);
+        $this->assertGreaterThanOrEqual(12, $a->gon);
+    }
+
+    public function testGetTheOriginalAngleValue()
+    {
+        $a = new Angle(4 * pi(), Angle::TYPE_TURN);
+        $this->assertEquals(4 * pi(), $a->get());
+    }
 }


### PR DESCRIPTION
Thank you for providing this great math package.Here is the changed log is as follows:
# Changed log

- add more testing.
- fix some errors during the testing.
- hook the [coveralls](https://coveralls.io) and it's the code coverage service.
- set the configuration for the ```.travis.yml```.
set the dist is precise because this [issue](https://github.com/travis-ci/travis-ci/issues/7693). And it can test well in PHP 5.3.

BTW, I think the coding style should be unified.
Perhaps we can use PHP-CS-Fixer or hook the [StyleCI](https://styleci.io) service and set the PSR-2 coding style.
What do you think?

Thanks.